### PR TITLE
Swap place in array_replace_recursive

### DIFF
--- a/src/Teepluss/Theme/Theme.php
+++ b/src/Teepluss/Theme/Theme.php
@@ -212,7 +212,7 @@ class Theme {
 			}
 		}
 
-		$config = array_replace_recursive($minorConfig, $config);
+		$config = array_replace_recursive($config, $minorConfig);
 		unset($config['themes']);
 
 		return $config;


### PR DESCRIPTION
This will make $minorConfig can rewrite on $config. It's important for 'inherit' index. First 'inherit' will written when Facade construct this class and 'inherit' from 'themeDefault' that we set it on config.php will run at first. This 'inherit' will store permanent ever. After that we call Theme::uses(), this will not change 'inherit' any more.
