### PR TITLE
Update Theme.php

### DIFF
--- a/src/Teepluss/Theme/Theme.php
+++ b/src/Teepluss/Theme/Theme.php
@@ -427,7 +427,8 @@ class Theme {
 		$this->fire('appendBefore', $this);
 
 		// Add asset path to asset container.
-		$this->asset->addPath($this->path().'/'.$this->getConfig('containerDir.asset'));
+		// Since every theme path start in public dir
+		$this->asset->addPath('public/'. $this->path().'/'.$this->getConfig('containerDir.asset'));
 
 		return $this;
 	}


### PR DESCRIPTION
By default the theme's path is not included in the asset's path with "public/" in it , therefore adding an asset using "usePath()" function will include incorrectly the asset (assuming "default" as a theme):

```
Theme::asset()->usePath()->add('script.js', 'script.js');

/// Result:
<script src="http://localhost/themes/default/assets/script.js"></script>
```

After this change, the result will be:

```
<script src="http://localhost/public/themes/default/assets/script.js"></script>
```

Since there is not a config var to set/add  explicitly "public/" in theme's path.
