### PR TITLE
Fix #102. Do not register abstract class.

### DIFF
--- a/src/Teepluss/Theme/ThemeServiceProvider.php
+++ b/src/Teepluss/Theme/ThemeServiceProvider.php
@@ -46,7 +46,6 @@ class ThemeServiceProvider extends ServiceProvider {
         // Register providers.
         $this->registerAsset();
         $this->registerTheme();
-        $this->registerWidget();
         $this->registerBreadcrumb();
 
         // Register commands.
@@ -85,19 +84,6 @@ class ThemeServiceProvider extends ServiceProvider {
         $this->app['theme'] = $this->app->share(function($app)
         {
             return new Theme($app['config'], $app['events'], $app['view'], $app['asset'], $app['files'], $app['breadcrumb']);
-        });
-    }
-
-    /**
-     * Register widget provider.
-     *
-     * @return void
-     */
-    public function registerWidget()
-    {
-        $this->app['widget'] = $this->app->share(function($app)
-        {
-            return new Widget($app['view']);
         });
     }
 


### PR DESCRIPTION
You can't add a IoC for abstract class. If Laravel try to instantiate the class, a 500 errors will be thrown.
If someone use-it to inject a concret class, the removal of the useless code will not affect his code.

I didn't try it, but I think that develop and master should be updated as well.