### PR TITLE
Update default theme selection issue.

### DIFF
--- a/src/Theme.php
+++ b/src/Theme.php
@@ -167,6 +167,9 @@ class Theme implements ThemeContract {
 
 		// Twig compiler.
 		$this->compilers['twig'] = new TwigCompiler($config, $view);
+		
+		// Set default theme.
+		$this->theme();
 	}
 
 	/**


### PR DESCRIPTION
Use theme instance without any settings which are theme and layout, default theme will not be selected as set configuration.

Exactly, I want to use this theme instance with out any chain-method when it resolve on some controllers.