### PR TITLE
Fixed blade statements in template for generated theme

### DIFF
--- a/src/templates/layout.blade.txt
+++ b/src/templates/layout.blade.txt
@@ -3,8 +3,8 @@
     <head>
         <title>{!! Theme::get('title') !!}</title>
         <meta charset="utf-8">
-        <meta name="keywords" content="{{! Theme::get('keywords') !!}">
-        <meta name="description" content="{{! Theme::get('description') !!}">
+        <meta name="keywords" content="{!! Theme::get('keywords') !!}">
+        <meta name="description" content="{!! Theme::get('description') !!}">
         {!! Theme::asset()->styles() !!}
         {!! Theme::asset()->scripts() !!}
     </head>


### PR DESCRIPTION
Blade statement for 'keywords' and 'description' placeholders did not show even after setting them.

Entered correct characters.