### PR TITLE
Add namespace support for rendering widgets

### DIFF
--- a/src/Theme.php
+++ b/src/Theme.php
@@ -667,10 +667,11 @@ class Theme implements ThemeContract
      *
      * @param  string $className
      * @param  array $attributes
+     * @param  string $namespace
      * @throws UnknownWidgetClassException
      * @return Teepluss\Theme\Widget
      */
-    public function widget($className, $attributes = array())
+    public function widget($className, $attributes = array(), $namespace = null)
     {
         static $widgets = array();
 
@@ -679,9 +680,17 @@ class Theme implements ThemeContract
             $className = ucfirst($className);
         }
 
-        $widgetNamespace = $this->getConfig('namespaces.widget');
-
-        $className = $widgetNamespace.'\\'.$className;
+        // if a namespace is specified, use it
+        if(!empty($namespace))
+        {
+            $className = $namespace.'\\'.$className;
+        }
+        // otherwise use the widget namespace from the package config
+        else
+        {
+            $widgetNamespace    = $this->getConfig('namespaces.widget');
+            $className          = $widgetNamespace.'\\'.$className;
+        }
 
         if (! $instance = array_get($widgets, $className)) {
             $reflector = new ReflectionClass($className);


### PR DESCRIPTION
I have a situation where I need to be able to render a widget that is part of another package, i.e. it is outside of the **App\Widgets** namespace.  (see #119)

I modified the Theme::widget() call to have an optional 3rd parameter for the namespace, which defaults to null.