### PR TITLE
for issue Move themes/ folder #105

### DIFF
--- a/src/Theme.php
+++ b/src/Theme.php
@@ -413,7 +413,7 @@ class Theme implements ThemeContract
         $this->fire('appendBefore', $this);
 
         // Add asset path to asset container.
-        $this->asset->addPath($this->path().'/'.$this->getConfig('containerDir.asset'));
+        $this->asset->addPath($this->theme.'/'.$this->getConfig('containerDir.asset'));
 
         return $this;
     }


### PR DESCRIPTION
Assets shouldn't depend on theme.themeDir, it should depend on the theme.assetUrl config.
It will give us a chance to put theme into resources directory instead of public directory.

consider following config and folder structure in laravel 5.1

* in config/theme.php

```
'assetUrl' => 'theme',`
'themeDir' => 'themes',
```

* folder structure

now you can put your themes under resources and put your assets into public/themes/{theme_name}/assets/